### PR TITLE
Better performing export

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -144,14 +144,14 @@ func (g *Game) PGN() string {
 
 // Export a game in PGN format
 func (g *Game) Export() string {
-	gm := chess.NewGame()
-	gm.AddTagPair("Site", "Slack ChessBot match")
-	gm.AddTagPair("White", g.Players[White].ID)
-	gm.AddTagPair("Black", g.Players[Black].ID)
-	for _, move := range g.game.Moves() {
-		gm.Move(move)
-	}
-	return gm.String()
+	regularNotation := chess.UseNotation(chess.AlgebraicNotation{})
+	longNotation := chess.UseNotation(chess.LongAlgebraicNotation{})
+	defer longNotation(g.game)
+	g.game.AddTagPair("Site", "Slack ChessBot match")
+	g.game.AddTagPair("White", g.Players[White].ID)
+	g.game.AddTagPair("Black", g.Players[Black].ID)
+	regularNotation(g.game)
+	return g.game.String()
 }
 
 // Outcome determines the outcome of the game (or no outcome)

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -1,0 +1,43 @@
+package game_test
+
+import (
+	"testing"
+
+	"github.com/cjsaylor/chessbot/game"
+)
+
+func TestExport(t *testing.T) {
+	gm := game.NewGame("1234", []game.Player{
+		game.Player{
+			ID: "a",
+		},
+		game.Player{
+			ID: "b",
+		},
+	}...)
+	gm.Move("d2d4")
+	gm.Move("d7d5")
+	result := gm.Export()
+	expected := "[Site \"Slack ChessBot match\"]\n[White \"a\"]\n[Black \"b\"]\n\n1.d4 d5  *"
+	if result != expected {
+		t.Errorf("expected %v got %v", expected, result)
+	}
+}
+
+func TestExportAndMoveMore(t *testing.T) {
+	gm := game.NewGame("1234", []game.Player{
+		game.Player{
+			ID: "a",
+		},
+		game.Player{
+			ID: "b",
+		},
+	}...)
+	gm.Move("d2d4")
+	// The implementation modifies the game in place.
+	// This test verifies the notation returns to LAN.
+	gm.Export()
+	if _, err := gm.Move("d7d5"); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
The chess lib API supports setting the notation of an existing game struct. This prevents having to repeat the moves when exporting.

This also adds some tests surrounding the export to make sure certain things still work after the fact (since the API to change the notation would need to be changed back for the simplified move input).