### PR TITLE
Takeback request

### DIFF
--- a/cmd/repl/main.go
+++ b/cmd/repl/main.go
@@ -68,6 +68,10 @@ func main() {
 			Pattern: regexp.MustCompile("^.*resign.*"),
 		},
 		{
+			Type:    integration.Takeback,
+			Pattern: regexp.MustCompile("^.*takeback.*"),
+		},
+		{
 			Type:    export,
 			Pattern: regexp.MustCompile("^.*export.*$"),
 		},
@@ -118,6 +122,19 @@ func main() {
 			}
 		case integration.Resign:
 			gm.Resign(gm.TurnPlayer())
+		case integration.Takeback:
+			currentTurnPlayer := gm.TurnPlayer()
+			var takebackPlayer game.Player
+			for _, player := range players {
+				if player.ID != currentTurnPlayer.ID {
+					takebackPlayer = player
+				}
+			}
+			if _, err := gm.Takeback(&takebackPlayer); err != nil {
+				fmt.Println(err)
+				fmt.Print("\n> ")
+				continue
+			}
 		}
 
 		store.StoreGame(gameID, gm)

--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
+	"time"
 
 	"github.com/cjsaylor/chessbot/analysis"
 	"github.com/cjsaylor/chessbot/config"
@@ -11,6 +13,10 @@ import (
 	"github.com/cjsaylor/chessbot/integration"
 	"github.com/cjsaylor/chessbot/rendering"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func main() {
 	config, err := config.ParseConfiguration()

--- a/game/game.go
+++ b/game/game.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/notnil/chess"
 )
@@ -42,7 +43,7 @@ type Game struct {
 	game        *chess.Game
 	Players     map[Color]Player
 	started     bool
-	lastMove    *chess.Move
+	lastMoved   time.Time
 	checkedTile *chess.Square
 }
 
@@ -53,6 +54,7 @@ func NewGame(ID string, players ...Player) *Game {
 		game: chess.NewGame(chess.UseNotation(chess.LongAlgebraicNotation{})),
 	}
 	attachPlayers(gm, players...)
+	gm.lastMoved = time.Time{}
 	return gm
 }
 
@@ -81,6 +83,7 @@ func NewGameFromFEN(ID string, fen string, players ...Player) (*Game, error) {
 		started: true,
 	}
 	attachPlayers(game, players...)
+	game.lastMoved = time.Time{}
 	return game, nil
 }
 
@@ -99,6 +102,7 @@ func NewGameFromPGN(ID string, pgn string, white Player, black Player) (*Game, e
 	game.Players[White] = white
 	black.color = Black
 	game.Players[Black] = black
+	game.lastMoved = time.Time{}
 	return game, nil
 }
 
@@ -185,6 +189,11 @@ func (g *Game) LastMove() *chess.Move {
 	return moves[len(moves)-1]
 }
 
+// LastMoved is the last time a move was made
+func (g *Game) LastMoved() time.Time {
+	return g.lastMoved
+}
+
 // Move a Chess piece based on standard algabreic notation (d2d4, etc)
 func (g *Game) Move(san string) (*chess.Move, error) {
 	err := g.game.MoveStr(san)
@@ -192,6 +201,7 @@ func (g *Game) Move(san string) (*chess.Move, error) {
 		return nil, err
 	}
 	g.started = true
+	g.lastMoved = time.Now()
 	return g.LastMove(), nil
 }
 

--- a/game/game.go
+++ b/game/game.go
@@ -72,16 +72,17 @@ func NewGame(ID string, players ...Player) *Game {
 }
 
 func attachPlayers(game *Game, players ...Player) {
-	randomOrder := make([]Player, len(players))
-	perm := rand.Perm(len(players))
-	for i, v := range perm {
-		randomOrder[v] = players[i]
+	playerList := []Player{}
+	playerList = append(playerList, players...)
+	rand.Shuffle(2, func(i, j int) {
+		playerList[i], playerList[j] = playerList[j], playerList[i]
+	})
+	playerList[0].color = White
+	playerList[1].color = Black
+	game.Players = map[Color]Player{
+		White: playerList[0],
+		Black: playerList[1],
 	}
-	game.Players = make(map[Color]Player)
-	randomOrder[0].color = White
-	game.Players[White] = randomOrder[0]
-	randomOrder[1].color = Black
-	game.Players[Black] = randomOrder[1]
 }
 
 // NewGameFromFEN will create a new game with a given FEN starting position

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -41,3 +41,21 @@ func TestExportAndMoveMore(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestLastMoveTimeRecorded(t *testing.T) {
+	gm := game.NewGame("1234", []game.Player{
+		game.Player{
+			ID: "a",
+		},
+		game.Player{
+			ID: "b",
+		},
+	}...)
+	if !gm.LastMoved().IsZero() {
+		t.Error("expected last move to be a zero value")
+	}
+	gm.Move("d2d4")
+	if gm.LastMoved().IsZero() {
+		t.Error("expected the last moved date to be set")
+	}
+}

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -2,6 +2,7 @@ package game_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cjsaylor/chessbot/game"
 )
@@ -57,5 +58,101 @@ func TestLastMoveTimeRecorded(t *testing.T) {
 	gm.Move("d2d4")
 	if gm.LastMoved().IsZero() {
 		t.Error("expected the last moved date to be set")
+	}
+}
+
+func TestTakebackRequestWithinThreshold(t *testing.T) {
+	takebackPlayer := game.Player{
+		ID: "a",
+	}
+	gm := game.NewGame("1234", []game.Player{
+		takebackPlayer,
+		game.Player{
+			ID: "b",
+		},
+	}...)
+	now := time.Now()
+	gm.SetTimeProvider(func() time.Time {
+		return now
+	})
+	gm.Move("d2d4")
+	if _, err := gm.Takeback(&takebackPlayer); err != nil {
+		t.Error(err)
+		t.Error("expected the takeback request to succeed")
+	}
+	gm.Move("d2d4")
+	gm.SetTimeProvider(func() time.Time {
+		return now.Add(game.TakebackThreshold + time.Second)
+	})
+	_, err := gm.Takeback(&takebackPlayer)
+	if err != game.ErrPastTimeThreshold {
+		t.Errorf("expected a takeback threshold exceeded error, got %v", err)
+	}
+}
+
+func TestTakebackRequestWithCorrectPlayer(t *testing.T) {
+	takebackPlayer := game.Player{
+		ID: "a",
+	}
+	otherTakebackPlayer := game.Player{
+		ID: "b",
+	}
+	gm := game.NewGame("1234", []game.Player{
+		takebackPlayer,
+		otherTakebackPlayer,
+	}...)
+	gm.Move("d2d4")
+	if _, err := gm.Takeback(&takebackPlayer); err != nil {
+		t.Error(err)
+		t.Error("expected takeback to succeed for the player that initiated the move")
+	}
+	gm.Move("d2d4")
+	if _, err := gm.Takeback(&otherTakebackPlayer); err == nil {
+		t.Error("expected takeback to fail due to \"current\" player requesting a takeback")
+	}
+	gm = game.NewGame("1234", []game.Player{
+		takebackPlayer,
+		otherTakebackPlayer,
+	}...)
+	gm.Move("d2d4")
+	gm.Move("d7d5")
+	gm.Takeback(&otherTakebackPlayer)
+	if _, err := gm.Takeback(&takebackPlayer); err != game.ErrPastTimeThreshold {
+		t.Error(err)
+		t.Error("expected a time threshold error due to the previous takeback wiping out the last moved time period")
+	}
+}
+
+func TestTakebackRequestWithCompletedGame(t *testing.T) {
+	gm := game.NewGame("1234", []game.Player{
+		game.Player{
+			ID: "a",
+		},
+		game.Player{
+			ID: "b",
+		},
+	}...)
+	gm.Move("d2d4")
+	resigner, _ := gm.PlayerByID("a")
+	gm.Resign(*resigner)
+	if _, err := gm.Takeback(resigner); err != game.ErrGameCompleted {
+		t.Error(err)
+		t.Error("expected the takeback to fail due to the game being over")
+	}
+}
+
+func TestTakebackRequestWithNoMoves(t *testing.T) {
+	gm := game.NewGame("1234", []game.Player{
+		game.Player{
+			ID: "a",
+		},
+		game.Player{
+			ID: "b",
+		},
+	}...)
+	requester := gm.TurnPlayer()
+	if _, err := gm.Takeback(&requester); err != game.ErrGameHasNoMoves {
+		t.Error(err)
+		t.Error("expected the takeback to fail due to not having any moves in the game yet")
 	}
 }

--- a/game/storage_test.go
+++ b/game/storage_test.go
@@ -42,6 +42,29 @@ func TestGameSavesAndIsRetrievable(t *testing.T) {
 	}
 }
 
+func TestGameSavesLastMoved(t *testing.T) {
+	dbSet, err := dbTestTable()
+	if err != nil {
+		t.Error(err)
+	}
+	for _, tt := range dbSet {
+		t.Run(tt.name, func(t *testing.T) {
+			gm := game.NewGame("1234", game.Player{ID: "1"}, game.Player{ID: "2"})
+			gm.Move("d2d4")
+			if err := tt.db.StoreGame("1234", gm); err != nil {
+				t.Error(err)
+			}
+			gm, err = tt.db.RetrieveGame("1234")
+			if err != nil {
+				t.Error(err)
+			}
+			if gm.LastMoved().IsZero() {
+				t.Error("expected the last moved time to be set")
+			}
+		})
+	}
+}
+
 func TestRetrieveGameThatDoesNotExist(t *testing.T) {
 	dbSet, err := dbTestTable()
 	if err != nil {

--- a/integration/command_parser.go
+++ b/integration/command_parser.go
@@ -17,6 +17,8 @@ const (
 	Move
 	// Resign represents a player's intention of resignation.
 	Resign
+	// Takeback represents a player's request to take back a previous move.
+	Takeback
 	// Help represents a player's need for help (UI or otherwise).
 	Help
 )


### PR DESCRIPTION
This PR adds a new command listener listing for `@chessbot takeback` or `@chessbot take back`. If the other player hasn't already made a move and it is within 1 minute of the previous move, it will revert the last move.

This requires an update to the sqlite db schema `games.last_moved datetime`.

Closes #10.