### PR TITLE
Player takeback request handling

### DIFF
--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -25,6 +25,7 @@ func main() {
 	}
 	var gameStorage game.GameStorage
 	var challengeStorage game.ChallengeStorage
+	var takebackStorage game.TakebackStorage
 	var authStorage integration.AuthStorage
 	if config.SqlitePath != "" {
 		gameSQLStore, err := game.NewSqliteStore(config.SqlitePath)
@@ -32,13 +33,18 @@ func main() {
 			log.Fatal(err)
 		}
 		authSQLStore, err := integration.NewSqliteStore(config.SqlitePath)
+		if err != nil {
+			log.Fatal(err)
+		}
 		gameStorage = gameSQLStore
 		challengeStorage = gameSQLStore
+		takebackStorage = gameSQLStore
 		authStorage = authSQLStore
 	} else {
 		memoryStore := game.NewMemoryStore()
 		gameStorage = memoryStore
 		challengeStorage = memoryStore
+		takebackStorage = memoryStore
 		authStorage = integration.NewMemoryStore()
 	}
 	renderLink := rendering.NewRenderLink(config.Hostname, config.SigningKey)
@@ -55,6 +61,7 @@ func main() {
 		AuthStorage:      authStorage,
 		GameStorage:      gameStorage,
 		ChallengeStorage: challengeStorage,
+		TakebackStorage:  takebackStorage,
 		LinkRenderer:     renderLink,
 	})
 	http.Handle("/slack/action", integration.SlackActionHandler{
@@ -63,6 +70,7 @@ func main() {
 		AuthStorage:      authStorage,
 		GameStorage:      gameStorage,
 		ChallengeStorage: challengeStorage,
+		TakebackStorage:  takebackStorage,
 		LinkRenderer:     renderLink,
 	})
 	http.Handle("/slack/oauth", integration.SlackOauthHandler{

--- a/game/game.go
+++ b/game/game.go
@@ -260,6 +260,12 @@ var ErrPlayerAlreadyMoved = errors.New("other player has already made a move")
 // ErrPastTimeThreshold is an error representing an action that failed due to taking place after a specific threshold
 var ErrPastTimeThreshold = fmt.Errorf("exceeded threshold of %v", TakebackThreshold)
 
+// IsPastTakebackThreshold determines if the last move is within the allowable takeback time period.
+func (g *Game) IsPastTakebackThreshold() bool {
+	elapsed := g.timeProvider().Sub(g.LastMoved())
+	return elapsed <= TakebackThreshold
+}
+
 // Takeback reverts the game to the previous move prior to the last move.
 // Note: If the first move of the game is taken back, the resulting move will be nil
 func (g *Game) Takeback(requestingPlayer *Player) (*chess.Move, error) {
@@ -272,9 +278,6 @@ func (g *Game) Takeback(requestingPlayer *Player) (*chess.Move, error) {
 	turnPlayer := g.TurnPlayer()
 	if requestingPlayer.ID == turnPlayer.ID {
 		return nil, ErrPlayerAlreadyMoved
-	}
-	if elapsed := g.timeProvider().Sub(g.LastMoved()); elapsed > TakebackThreshold {
-		return nil, ErrPastTimeThreshold
 	}
 	newGame := chess.NewGame(chess.UseNotation(chess.LongAlgebraicNotation{}))
 	moves := g.game.Moves()

--- a/game/game.go
+++ b/game/game.go
@@ -286,7 +286,7 @@ func (g *Game) Takeback(requestingPlayer *Player) (*chess.Move, error) {
 	}
 	g.game = newGame
 	// Prevent cascading takebacks
-	g.lastMoved = time.Time{}
+	g.lastMoved = g.timeProvider().Add(-TakebackThreshold - time.Second)
 	return g.LastMove(), nil
 }
 

--- a/game/game.go
+++ b/game/game.go
@@ -262,7 +262,7 @@ var ErrPastTimeThreshold = fmt.Errorf("exceeded threshold of %v", TakebackThresh
 
 // IsPastTakebackThreshold determines if the last move is within the allowable takeback time period.
 func (g *Game) IsPastTakebackThreshold() bool {
-	return g.timeProvider().Sub(g.LastMoved()) <= TakebackThreshold
+	return g.timeProvider().Sub(g.LastMoved()) > TakebackThreshold
 }
 
 // Takeback reverts the game to the previous move prior to the last move.

--- a/game/game.go
+++ b/game/game.go
@@ -275,6 +275,12 @@ func (g *Game) IsPastTakebackThreshold() bool {
 	return g.timeProvider().Sub(g.LastMoved()) > TakebackThreshold
 }
 
+// IsExtendedTakebackAllowed determines if a player may request a take back after
+// the time threshold has expired
+func (g *Game) IsExtendedTakebackAllowed(requestingPlayer *Player) bool {
+	return g.IsPastTakebackThreshold() && requestingPlayer.ID != g.TurnPlayer().ID
+}
+
 // Takeback reverts the game to the previous move prior to the last move.
 // Note: If the first move of the game is taken back, the resulting move will be nil
 func (g *Game) Takeback(requestingPlayer *Player) (*chess.Move, error) {
@@ -308,4 +314,23 @@ func (g *Game) SetTimeProvider(provider TimeProvider) {
 // String representation of the current game state (draws an ascii board)
 func (g *Game) String() string {
 	return g.game.Position().Board().Draw()
+}
+
+// Takeback represents a takeback request
+type Takeback struct {
+	CurrentGame *Game
+	FENSnapshot string
+}
+
+// NewTakeback constructs a new takeback request
+func NewTakeback(game *Game) *Takeback {
+	return &Takeback{
+		CurrentGame: game,
+		FENSnapshot: game.FEN(),
+	}
+}
+
+// IsValidTakeback determines if this takeback request is valid
+func (t *Takeback) IsValidTakeback() bool {
+	return t.CurrentGame.FEN() == t.FENSnapshot
 }

--- a/game/game.go
+++ b/game/game.go
@@ -19,6 +19,7 @@ type Challenge struct {
 	ChannelID    string
 }
 
+// Color represents the game color (white/black)
 type Color string
 
 // White represents the color of the white set.
@@ -102,6 +103,7 @@ func NewGameFromFEN(ID string, fen string, players ...Player) (*Game, error) {
 	return game, nil
 }
 
+// NewGameFromPGN will create a new game at the state expressed by a provided PGN
 func NewGameFromPGN(ID string, pgn string, white Player, black Player) (*Game, error) {
 	reader := strings.NewReader(pgn)
 	gameState, err := chess.PGN(reader)

--- a/game/game.go
+++ b/game/game.go
@@ -262,8 +262,7 @@ var ErrPastTimeThreshold = fmt.Errorf("exceeded threshold of %v", TakebackThresh
 
 // IsPastTakebackThreshold determines if the last move is within the allowable takeback time period.
 func (g *Game) IsPastTakebackThreshold() bool {
-	elapsed := g.timeProvider().Sub(g.LastMoved())
-	return elapsed <= TakebackThreshold
+	return g.timeProvider().Sub(g.LastMoved()) <= TakebackThreshold
 }
 
 // Takeback reverts the game to the previous move prior to the last move.

--- a/game/game.go
+++ b/game/game.go
@@ -142,6 +142,16 @@ func (g *Game) TurnPlayer() Player {
 	return g.Players[g.Turn()]
 }
 
+// OtherPlayer returns ...the other player given a player
+func (g *Game) OtherPlayer(player *Player) *Player {
+	for _, other := range g.Players {
+		if other.ID != player.ID {
+			return &other
+		}
+	}
+	return nil
+}
+
 // Turn returns which color should move next
 func (g *Game) Turn() Color {
 	switch g.game.Position().Turn() {

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -79,19 +79,16 @@ func TestTakebackRequestWithinThreshold(t *testing.T) {
 	gm.SetTimeProvider(func() time.Time {
 		return now
 	})
-	takebackPlayer := gm.TurnPlayer()
 	gm.Move("d2d4")
-	if _, err := gm.Takeback(&takebackPlayer); err != nil {
-		t.Error(err)
-		t.Error("expected the takeback request to succeed")
+	if withinThreshold := gm.IsPastTakebackThreshold(); !withinThreshold {
+		t.Error("expected response to be true, got false")
 	}
 	gm.Move("d2d4")
 	gm.SetTimeProvider(func() time.Time {
 		return now.Add(game.TakebackThreshold + time.Second)
 	})
-	_, err := gm.Takeback(&takebackPlayer)
-	if err != game.ErrPastTimeThreshold {
-		t.Errorf("expected a takeback threshold exceeded error, got %v", err)
+	if withinThreshold := gm.IsPastTakebackThreshold(); withinThreshold {
+		t.Error("expected response to be false, got true")
 	}
 }
 

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -114,8 +114,7 @@ func TestTakebackRequestWithCorrectPlayer(t *testing.T) {
 	}
 	gm.Move("d7d5")
 	gm.Takeback(&otherTakebackPlayer)
-	if _, err := gm.Takeback(&takebackPlayer); err != game.ErrPastTimeThreshold {
-		t.Error(err)
+	if isWithinThreshold := gm.IsPastTakebackThreshold(); isWithinThreshold {
 		t.Error("expected a time threshold error due to the previous takeback wiping out the last moved time period")
 	}
 }

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -151,3 +151,18 @@ func TestTakebackRequestWithNoMoves(t *testing.T) {
 		t.Error("expected the takeback to fail due to not having any moves in the game yet")
 	}
 }
+
+func TestGetOtherPlayer(t *testing.T) {
+	gm := game.NewGame("1234", []game.Player{
+		{
+			ID: "a",
+		},
+		{
+			ID: "b",
+		},
+	}...)
+	turnPlayer := gm.TurnPlayer()
+	if otherPlayer := gm.OtherPlayer(&turnPlayer); otherPlayer.ID == turnPlayer.ID {
+		t.Error("expected a different player than the current turn player")
+	}
+}

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -166,3 +166,42 @@ func TestGetOtherPlayer(t *testing.T) {
 		t.Error("expected a different player than the current turn player")
 	}
 }
+
+func TestExtendedTakebackRequestAllowed(t *testing.T) {
+	gm := game.NewGame("1234", []game.Player{
+		{
+			ID: "a",
+		},
+		{
+			ID: "b",
+		},
+	}...)
+	gm.Move("d2d4")
+	now := time.Now()
+	gm.SetTimeProvider(func() time.Time {
+		return now.Add(game.TakebackThreshold + time.Second)
+	})
+	turnPlayer := gm.TurnPlayer()
+	requester := gm.OtherPlayer(&turnPlayer)
+	if !gm.IsExtendedTakebackAllowed(requester) {
+		t.Error("expected extended takeback to be allowed")
+	}
+}
+
+func TestTakebackSnapshotValidation(t *testing.T) {
+	gm := game.NewGame("1234", []game.Player{
+		{
+			ID: "a",
+		},
+		{
+			ID: "b",
+		},
+	}...)
+	gm.Move("d2d4")
+	takeback := game.NewTakeback(gm)
+	gm.Move("d7d5")
+	if takeback.IsValidTakeback() {
+		t.Error("expected not to be a valid takeback since the signature of the game has been altered")
+	}
+
+}

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -14,10 +14,10 @@ func init() {
 
 func TestExport(t *testing.T) {
 	gm := game.NewGame("1234", []game.Player{
-		game.Player{
+		{
 			ID: "a",
 		},
-		game.Player{
+		{
 			ID: "b",
 		},
 	}...)
@@ -32,10 +32,10 @@ func TestExport(t *testing.T) {
 
 func TestExportAndMoveMore(t *testing.T) {
 	gm := game.NewGame("1234", []game.Player{
-		game.Player{
+		{
 			ID: "a",
 		},
-		game.Player{
+		{
 			ID: "b",
 		},
 	}...)
@@ -50,10 +50,10 @@ func TestExportAndMoveMore(t *testing.T) {
 
 func TestLastMoveTimeRecorded(t *testing.T) {
 	gm := game.NewGame("1234", []game.Player{
-		game.Player{
+		{
 			ID: "a",
 		},
-		game.Player{
+		{
 			ID: "b",
 		},
 	}...)
@@ -68,10 +68,10 @@ func TestLastMoveTimeRecorded(t *testing.T) {
 
 func TestTakebackRequestWithinThreshold(t *testing.T) {
 	gm := game.NewGame("1234", []game.Player{
-		game.Player{
+		{
 			ID: "a",
 		},
-		game.Player{
+		{
 			ID: "b",
 		},
 	}...)
@@ -93,10 +93,10 @@ func TestTakebackRequestWithinThreshold(t *testing.T) {
 
 func TestTakebackRequestWithCorrectPlayer(t *testing.T) {
 	gm := game.NewGame("1234", []game.Player{
-		game.Player{
+		{
 			ID: "a",
 		},
-		game.Player{
+		{
 			ID: "b",
 		},
 	}...)
@@ -120,10 +120,10 @@ func TestTakebackRequestWithCorrectPlayer(t *testing.T) {
 
 func TestTakebackRequestWithCompletedGame(t *testing.T) {
 	gm := game.NewGame("1234", []game.Player{
-		game.Player{
+		{
 			ID: "a",
 		},
-		game.Player{
+		{
 			ID: "b",
 		},
 	}...)
@@ -138,10 +138,10 @@ func TestTakebackRequestWithCompletedGame(t *testing.T) {
 
 func TestTakebackRequestWithNoMoves(t *testing.T) {
 	gm := game.NewGame("1234", []game.Player{
-		game.Player{
+		{
 			ID: "a",
 		},
-		game.Player{
+		{
 			ID: "b",
 		},
 	}...)

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -80,15 +80,14 @@ func TestTakebackRequestWithinThreshold(t *testing.T) {
 		return now
 	})
 	gm.Move("d2d4")
-	if withinThreshold := gm.IsPastTakebackThreshold(); !withinThreshold {
-		t.Error("expected response to be true, got false")
+	if pastThreshold := gm.IsPastTakebackThreshold(); pastThreshold {
+		t.Error("expected response to be false, got true")
 	}
-	gm.Move("d2d4")
 	gm.SetTimeProvider(func() time.Time {
 		return now.Add(game.TakebackThreshold + time.Second)
 	})
-	if withinThreshold := gm.IsPastTakebackThreshold(); withinThreshold {
-		t.Error("expected response to be false, got true")
+	if pastThreshold := gm.IsPastTakebackThreshold(); !pastThreshold {
+		t.Error("expected response to be true, got false")
 	}
 }
 

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -113,7 +113,7 @@ func TestTakebackRequestWithCorrectPlayer(t *testing.T) {
 	}
 	gm.Move("d7d5")
 	gm.Takeback(&otherTakebackPlayer)
-	if isWithinThreshold := gm.IsPastTakebackThreshold(); isWithinThreshold {
+	if isPastThreshold := gm.IsPastTakebackThreshold(); !isPastThreshold {
 		t.Error("expected a time threshold error due to the previous takeback wiping out the last moved time period")
 	}
 }

--- a/game/memory.go
+++ b/game/memory.go
@@ -9,6 +9,7 @@ import (
 type MemoryStore struct {
 	games      map[string]*Game
 	challenges map[string]*Challenge
+	takebacks  map[string]*Takeback
 }
 
 // NewMemoryStore returns a MemoryStore pointer
@@ -55,5 +56,26 @@ func (m *MemoryStore) StoreChallenge(c *Challenge) error {
 func (m *MemoryStore) RemoveChallenge(challengerID string, challengedID string) error {
 	key := challengerID + challengedID
 	delete(m.challenges, key)
+	return nil
+}
+
+// StoreTakeback stores a takeback request
+func (m *MemoryStore) StoreTakeback(takeback *Takeback) error {
+	key := takeback.CurrentGame.ID
+	m.takebacks[key] = takeback
+	return nil
+}
+
+// RetrieveTakeback finds a takeback request by a game ID
+func (m *MemoryStore) RetrieveTakeback(gameID string) (*Takeback, error) {
+	if takeback, ok := m.takebacks[gameID]; ok {
+		return takeback, nil
+	}
+	return nil, fmt.Errorf("Takeback not found for provided game ID")
+}
+
+// RemoveTakeback removes a takeback request from storage
+func (m *MemoryStore) RemoveTakeback(takeback *Takeback) error {
+	delete(m.takebacks, takeback.CurrentGame.ID)
 	return nil
 }

--- a/game/storage.go
+++ b/game/storage.go
@@ -12,3 +12,10 @@ type ChallengeStorage interface {
 	StoreChallenge(challenge *Challenge) error
 	RemoveChallenge(challengerID string, challengedID string) error
 }
+
+// TakebackStorage is an interface to be implemented for persisting takeback requests.
+type TakebackStorage interface {
+	RetrieveTakeback(gameID string) (*Takeback, error)
+	StoreTakeback(takeback *Takeback) error
+	RemoveTakeback(takeback *Takeback) error
+}

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/caarlos0/env v3.3.0+incompatible h1:jCfY0ilpzC2FFViyZyDKCxKybDESTwaR+ebh8zm6AOE=
-github.com/caarlos0/env v3.3.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
 github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=
 github.com/caarlos0/env v3.5.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
 github.com/cjsaylor/chessimage v0.0.0-20190107020940-8abad33612f4 h1:U70Ohwln5iU8lFp1hUaCJG2MgHsnwsAkMWF4swb8z6g=

--- a/integration/events.go
+++ b/integration/events.go
@@ -276,6 +276,10 @@ func (s SlackHandler) handleTakebackCommand(gameID string, ev *slackevents.AppMe
 		s.sendError(gameID, ev.Channel, "I couldn't find you as part of this game.")
 		return
 	}
+	if gm.IsPastTakebackThreshold() {
+		s.sendError(gameID, ev.Channel, fmt.Sprint(game.ErrPastTimeThreshold))
+		return
+	}
 	chessMove, err := gm.Takeback(player)
 	if err != nil {
 		s.sendError(gameID, ev.Channel, fmt.Sprintf("Take back request failed: %v", err))

--- a/integration/events.go
+++ b/integration/events.go
@@ -301,6 +301,12 @@ func (s SlackHandler) handleTakebackCommand(gameID string, ev *slackevents.AppMe
 				},
 			},
 		))
+		s.SlackClient.PostEphemeral(
+			ev.Channel,
+			ev.User,
+			slack.MsgOptionTS(ev.TimeStamp),
+			slack.MsgOptionText(fmt.Sprintf("Take back request sent to <@%v>", gm.TurnPlayer().ID), false),
+		)
 		return
 	}
 	chessMove, err := gm.Takeback(player)

--- a/integration/events.go
+++ b/integration/events.go
@@ -24,6 +24,7 @@ type SlackHandler struct {
 	AuthStorage      AuthStorage
 	GameStorage      game.GameStorage
 	ChallengeStorage game.ChallengeStorage
+	TakebackStorage  game.TakebackStorage
 	LinkRenderer     rendering.RenderLink
 }
 
@@ -276,8 +277,30 @@ func (s SlackHandler) handleTakebackCommand(gameID string, ev *slackevents.AppMe
 		s.sendError(gameID, ev.Channel, "I couldn't find you as part of this game.")
 		return
 	}
-	if gm.IsPastTakebackThreshold() {
-		s.sendError(gameID, ev.Channel, fmt.Sprint(game.ErrPastTimeThreshold))
+	if gm.IsExtendedTakebackAllowed(player) {
+		s.TakebackStorage.StoreTakeback(game.NewTakeback(gm))
+		s.SlackClient.PostEphemeral(ev.Channel, gm.TurnPlayer().ID, slack.MsgOptionTS(ev.TimeStamp), slack.MsgOptionAttachments(
+			slack.Attachment{
+				Text:       fmt.Sprintf("<@%v> has requested a takeback.", ev.User),
+				Fallback:   "Unable to request a takeback.",
+				CallbackID: "takeback_response",
+				Actions: []slack.AttachmentAction{
+					{
+						Name:  gameID,
+						Text:  "Allow Takeback",
+						Type:  "button",
+						Value: "allow",
+					},
+					{
+						Name:  gameID,
+						Text:  "Decline",
+						Type:  "button",
+						Style: "danger",
+						Value: "decline",
+					},
+				},
+			},
+		))
 		return
 	}
 	chessMove, err := gm.Takeback(player)


### PR DESCRIPTION
Resolve #52 

Issuing a takeback request via `@chessbot takeback` automatically does the takeback if the other player hasn't moved and it is within 1 minute of the previous move.

This PR adds the ability to issue a takeback request after the 1 minute threshold, but asks the opposing player permission. The opposing player then has the option to allow the takeback or decline it.

Me requesting the takeback:

![image](https://user-images.githubusercontent.com/157755/96335906-e1177500-1049-11eb-8c4f-91dfc70a753f.png)

Opposing player receiving the takeback request:

![image](https://user-images.githubusercontent.com/157755/96335912-e96fb000-1049-11eb-8443-4e025adef8e5.png)

Opposing player accepting the takeback request:

![image](https://user-images.githubusercontent.com/157755/96335915-f1c7eb00-1049-11eb-8a26-895b1ac40aff.png)

Opposing player declining the takeback request:

![image](https://user-images.githubusercontent.com/157755/96335924-f9878f80-1049-11eb-97ad-ff887c3411d5.png)
